### PR TITLE
Call `LossLayer::LayerSetUp` in `SmoothL1LossLayer`.

### DIFF
--- a/src/caffe/layers/smooth_L1_loss_layer.cpp
+++ b/src/caffe/layers/smooth_L1_loss_layer.cpp
@@ -12,6 +12,7 @@ namespace caffe {
 template <typename Dtype>
 void SmoothL1LossLayer<Dtype>::LayerSetUp(
   const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  LossLayer<Dtype>::LayerSetUp(bottom, top);
   SmoothL1LossParameter loss_param = this->layer_param_.smooth_l1_loss_param();
   sigma2_ = loss_param.sigma() * loss_param.sigma();
   has_weights_ = (bottom.size() >= 3);


### PR DESCRIPTION
If `SmoothL1LossLayer` doesn't have a `loss_weight` explicitly set, then it currently defaults to 0:

```
I0426 00:15:33.254120  1242 solver.cpp:228] Iteration 11360, loss = 0
I0426 00:15:33.254154  1242 solver.cpp:244]     Train net output #0: loss = 0.0142144
```

In particular, note the first line, in which the loss is 0 even though the output is nonzero.

This PR is a 1-line change that calls the parent `LayerSetUp` method, which does the work of setting the default `loss_weight` to 1.

(On a somewhat related note, in the py-faster-rcnn repository it seems to be the case that `loss_weight` is always explicitly set, so this bug was never an issue there.)
