### PR TITLE
Update test_smooth_L1_loss_layer.cpp

### DIFF
--- a/src/caffe/test/test_smooth_L1_loss_layer.cpp
+++ b/src/caffe/test/test_smooth_L1_loss_layer.cpp
@@ -8,7 +8,7 @@
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
 #include "caffe/filler.hpp"
-#include "caffe/vision_layers.hpp"
+//#include "caffe/vision_layers.hpp"
 #include "caffe/fast_rcnn_layers.hpp"
 
 #include "caffe/test/test_caffe_main.hpp"


### PR DESCRIPTION
Bug fix. The `make test` doesn't compile because there is no vision_layers.hpp in this caffe version.
